### PR TITLE
Add package.json and index.html for codesandbox support

### DIFF
--- a/write-a-recursive-function/index.html
+++ b/write-a-recursive-function/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Parcel Sandbox</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <div id="app"></div>
+    <h1>Look in the console 👇</h1>
+    <script src="src/index.js"></script>
+  </body>
+</html>

--- a/write-a-recursive-function/package.json
+++ b/write-a-recursive-function/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "recursive function",
+  "version": "1.0.0",
+  "description": "Write a Recursive Function",
+  "main": "index.html",
+  "scripts": {
+    "start": "parcel index.html --open",
+    "build": "parcel build index.html"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@babel/core": "7.2.0",
+    "parcel-bundler": "^1.6.1"
+  },
+  "keywords": [
+    "javascript",
+    "starter"
+  ]
+}


### PR DESCRIPTION
We can [pull github repo folders into codesandbox](https://howtoegghead.com/instructor/github-to-codesandbox/)! They just need a `index.html` and `package.json`

The embed ends up looking really nice and would show just the JS file and console.

[Example](https://codesandbox.io/embed/stoic-kare-18h4o?expanddevtools=1&fontsize=14&hidenavigation=1&theme=dark)
![Image 2020-05-06 at 6 17 23 PM](https://user-images.githubusercontent.com/6188161/81233977-d9956f80-8fc5-11ea-8fcf-f7df7771fc6b.png)


![](https://media3.giphy.com/media/s2qXK8wAvkHTO/giphy.gif?cid=5a38a5a2167108e7dd159ffde4c84c1ea242d08e22eb0fc2&rid=giphy.gif)

